### PR TITLE
Fixed crashes while opening creative tabs in Neoforge development platform.

### DIFF
--- a/common/src/main/java/dev/tr3ymix/cfm_wap/CFM_WAP.java
+++ b/common/src/main/java/dev/tr3ymix/cfm_wap/CFM_WAP.java
@@ -24,7 +24,7 @@ public final class CFM_WAP {
 
 
 
-        if(Platform.getEnvironment() == Env.CLIENT) {
+        if(Platform.getEnvironment() == Env.CLIENT && Platform.isFabric()) {
             //noinspection UnstableApiUsage
             CreativeTabRegistry.modify(
                     CreativeTabRegistry.defer(ModCreativeTabs.MAIN.getId()),


### PR DESCRIPTION
Hi there. I noticed while opening creative tabs in Neoforge development environment it crashes, but it works will in Fabric environment. I tried to fix this by checking current mod platform.